### PR TITLE
checking the token storage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_application_1/src/services/auth_storage.dart';
 import 'package:flutter_application_1/src/ui/screens/registration/registration_page.dart';
 import 'package:flutter_application_1/src/ui/screens/main/main_screen.dart';
 import 'package:flutter_application_1/src/ui/screens/welcome_page_screens/choose_role_screen.dart';
@@ -10,7 +11,9 @@ import './src/ui/themes/app_theme.dart';
 import 'src/ui/shared_pages/success_page.dart.dart';
 import 'src/ui/screens/welcome_page_screens/greeting_screen.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await AuthStorage.init();
   runApp(const Marcketplace());
 }
 

--- a/lib/src/services/auth_storage.dart
+++ b/lib/src/services/auth_storage.dart
@@ -1,22 +1,43 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class AuthStorage {
-  static const _storage = FlutterSecureStorage();
+  static FlutterSecureStorage? _secureStorage;
+  static SharedPreferences? _prefs;
   static const _tokenKey = 'auth_token';
 
+  static Future<void> init() async {
+    if (kIsWeb) {
+      _prefs = await SharedPreferences.getInstance();
+    } else {
+      _secureStorage = const FlutterSecureStorage();
+    }
+  }
+
   static Future<void> saveToken(String token) async {
-    await _storage.write(key: _tokenKey, value: token);
+    if (kIsWeb) {
+      await _prefs?.setString(_tokenKey, token);
+    } else {
+      await _secureStorage?.write(key: _tokenKey, value: token);
+    }
     print('Token saved: $token');
   }
 
   static Future<String?> getToken() async {
-    final token = await _storage.read(key: _tokenKey);
-    print('Retrieved token: $token');
-    return token;
+    if (kIsWeb) {
+      return _prefs?.getString(_tokenKey);
+    } else {
+      return await _secureStorage?.read(key: _tokenKey);
+    }
   }
 
   static Future<void> deleteToken() async {
-    await _storage.delete(key: _tokenKey);
+    if (kIsWeb) {
+      await _prefs?.remove(_tokenKey);
+    } else {
+      await _secureStorage?.delete(key: _tokenKey);
+    }
     print('Token deleted');
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce web support for token storage using SharedPreferences, while continuing to use FlutterSecureStorage for native platforms. Initialize the storage based on the platform during app startup.

Enhancements:
- Use SharedPreferences for token storage on web platforms.
- Initialize AuthStorage during app startup.