### PR TITLE
fix duplicate _emailController definition

### DIFF
--- a/lib/src/ui/screens/reset_password/forgot_password.page.dart
+++ b/lib/src/ui/screens/reset_password/forgot_password.page.dart
@@ -11,7 +11,8 @@ import '../../widgets/auth_widgets/auth_field.dart';
 import '../../widgets/auth_widgets/auth_button.dart';
 
 class ForgotPasswordPage extends StatefulWidget {
-  const ForgotPasswordPage({super.key});
+  final String? email;
+  const ForgotPasswordPage({super.key, this.email});
 
   @override
   State<ForgotPasswordPage> createState() => _ForgotPasswordPageState();
@@ -20,13 +21,15 @@ class ForgotPasswordPage extends StatefulWidget {
 class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
   String? _emailError;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  final TextEditingController _emailController = TextEditingController();
   bool _isButtonDisabled = true;
+  late final TextEditingController _emailController;
 
   @override
   void initState() {
     super.initState();
+    _emailController = TextEditingController(text: widget.email ?? "");
     _emailController.addListener(_updateButtonState);
+    _updateButtonState();
   }
 
   void _updateButtonState() {

--- a/lib/src/ui/widgets/login_widgets/forgot_password_button.dart
+++ b/lib/src/ui/widgets/login_widgets/forgot_password_button.dart
@@ -3,7 +3,8 @@ import 'package:flutter_application_1/src/ui/screens/reset_password/forgot_passw
 import '../../themes/app_theme.dart';
 
 class ForgotPasswordButton extends StatelessWidget {
-  const ForgotPasswordButton({super.key});
+  final String? email;
+  const ForgotPasswordButton({super.key, this.email});
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +19,7 @@ class ForgotPasswordButton extends StatelessWidget {
             Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => const ForgotPasswordPage(),
+                builder: (context) => ForgotPasswordPage(email: email),
               ),
             );
           },

--- a/lib/src/ui/widgets/login_widgets/login_mobile_layout.dart
+++ b/lib/src/ui/widgets/login_widgets/login_mobile_layout.dart
@@ -79,7 +79,10 @@ class LoginMobileLayout extends StatelessWidget {
                         validator: validatePassword,
                         isObscureText: true,
                       ),
-                      const ForgotPasswordButton(),
+                      ForgotPasswordButton(
+                          email: emailController.text.isNotEmpty
+                              ? emailController.text
+                              : null),
                       const SizedBox(height: 30),
                       AuthButton(
                         text: 'Увійти в акаунт',


### PR DESCRIPTION
## Summary by Sourcery

Modify ForgotPasswordPage and related components to support optional pre-filled email

Bug Fixes:
- Resolve duplicate _emailController definition by using late initialization

Enhancements:
- Update ForgotPasswordPage and ForgotPasswordButton to accept an optional email parameter
- Modify initialization of email controller to use pre-filled email when available