### PR TITLE
added a settings widget to the account page

### DIFF
--- a/lib/src/ui/screens/seller_profile/seller_profile_screen.dart
+++ b/lib/src/ui/screens/seller_profile/seller_profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_application_1/src/ui/widgets/seller_profile_widgets/empt
 import 'package:flutter_application_1/src/ui/widgets/seller_profile_widgets/chat/messages_widget.dart';
 import 'package:flutter_application_1/src/ui/widgets/seller_profile_widgets/chat/seller_sidebar_widget.dart';
 import 'package:flutter_application_1/src/ui/widgets/seller_profile_widgets/profile/profile_widget.dart';
+import 'package:flutter_application_1/src/ui/widgets/seller_profile_widgets/settings/account_settings_widget.dart';
 import 'package:flutter_application_1/src/ui/widgets/seller_profile_widgets/support/support_widget.dart';
 
 class SellerProfileScreen extends StatefulWidget {
@@ -59,7 +60,7 @@ class _SellerProfileScreenState extends State<SellerProfileScreen> {
       case "support":
         return const SupportWidget();
       case "settings":
-        return const Center(child: Text('Сторінка налаштувань'));
+        return const AccountSettingsWidget();
       default:
         return const Center(child: Text('Невідома сторінка'));
     }
@@ -68,7 +69,6 @@ class _SellerProfileScreenState extends State<SellerProfileScreen> {
   @override
   Widget build(BuildContext context) {
     return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         SizedBox(
           width: 198,

--- a/lib/src/ui/widgets/seller_profile_widgets/profile/profile_field_widget.dart
+++ b/lib/src/ui/widgets/seller_profile_widgets/profile/profile_field_widget.dart
@@ -19,9 +19,9 @@ class ProfileField extends StatelessWidget {
             decoration: InputDecoration(
               hintText: 'Введіть тут',
               filled: true,
-              fillColor: Colors.grey.shade300,
-              hoverColor: Colors.grey.shade300,
-              focusColor: Colors.grey.shade300,
+              fillColor: Colors.grey.shade200,
+              hoverColor: Colors.grey.shade200,
+              focusColor: Colors.grey.shade200,
               border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide.none),

--- a/lib/src/ui/widgets/seller_profile_widgets/profile/profile_widget.dart
+++ b/lib/src/ui/widgets/seller_profile_widgets/profile/profile_widget.dart
@@ -56,7 +56,10 @@ class ProfileWidget extends StatelessWidget {
             ),
             OutlinedButton(
               onPressed: () {},
-              style: OutlinedButton.styleFrom(side: BorderSide.none),
+              style: OutlinedButton.styleFrom(
+                side: BorderSide.none,
+                foregroundColor: Colors.black,
+              ),
               child: const Text('Змінити фото'),
             ),
           ],

--- a/lib/src/ui/widgets/seller_profile_widgets/settings/account_settings_widget.dart
+++ b/lib/src/ui/widgets/seller_profile_widgets/settings/account_settings_widget.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_application_1/src/ui/widgets/seller_profile_widgets/settings/account_switch_widget.dart';
+
+class AccountSettingsWidget extends StatefulWidget {
+  const AccountSettingsWidget({super.key});
+
+  @override
+  State<AccountSettingsWidget> createState() => _AccountSettingsWidgetState();
+}
+
+class _AccountSettingsWidgetState extends State<AccountSettingsWidget> {
+  String selectedTheme = 'light';
+  String selectedLanguage = 'ukr';
+  bool _emailNotifications = true;
+  bool _pushNotifications = false;
+
+  @override
+  Widget build(context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Сповіщення',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        AccountSwitchWidget(
+          label: 'Пошта',
+          value: _emailNotifications,
+          onChanged: (newValue) {
+            setState(() {
+              _emailNotifications = newValue;
+            });
+          },
+        ),
+        const SizedBox(height: 8),
+        AccountSwitchWidget(
+          label: 'Пуш-сповіщення',
+          value: _pushNotifications,
+          onChanged: (newValue) {
+            setState(() {
+              _pushNotifications = newValue;
+            });
+          },
+        ),
+        const SizedBox(height: 40),
+        const Text(
+          'Тема',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        AccountSwitchWidget(
+          label: 'Світла',
+          value: selectedTheme == 'light',
+          onChanged: (newValue) {
+            if (newValue) {
+              setState(() {
+                selectedTheme = 'light';
+              });
+            }
+          },
+        ),
+        const SizedBox(height: 8),
+        AccountSwitchWidget(
+          label: 'Темна',
+          value: selectedTheme == 'dark',
+          onChanged: (newValue) {
+            if (newValue) {
+              setState(() {
+                selectedTheme = 'dark';
+              });
+            }
+          },
+        ),
+        const SizedBox(height: 40),
+        const Text(
+          'Мова',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        AccountSwitchWidget(
+          label: 'Українська',
+          value: selectedLanguage == 'ukr',
+          onChanged: (newValue) {
+            if (newValue) {
+              setState(() {
+                selectedLanguage = 'ukr';
+              });
+            }
+          },
+        ),
+        const SizedBox(height: 8),
+        AccountSwitchWidget(
+          label: 'Англійська',
+          value: selectedLanguage == 'en',
+          onChanged: (newValue) {
+            if (newValue) {
+              setState(() {
+                selectedLanguage = 'en';
+              });
+            }
+          },
+        ),
+        const SizedBox(height: 40),
+        const Text(
+          'Акаунт',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        ElevatedButton(
+          onPressed: () {},
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size(213, 40),
+            backgroundColor: Colors.red,
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+          child: const Text(
+            'Видалити акаунт',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w200),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/src/ui/widgets/seller_profile_widgets/settings/account_switch_widget.dart
+++ b/lib/src/ui/widgets/seller_profile_widgets/settings/account_switch_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class AccountSwitchWidget extends StatelessWidget {
+  final String label;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  const AccountSwitchWidget({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(width: 150, child: Text(label)),
+        const SizedBox(width: 120),
+        SwitchTheme(
+          data: SwitchThemeData(
+            trackColor: WidgetStateProperty.resolveWith<Color?>(
+              (states) {
+                if (states.contains(WidgetState.selected)) {
+                  return Colors.orange;
+                }
+                return Colors.grey.shade300;
+              },
+            ),
+            thumbColor: WidgetStateProperty.all(Colors.white),
+            trackOutlineColor: WidgetStateProperty.all(Colors.transparent),
+          ),
+          child: Switch(
+            value: value,
+            onChanged: onChanged,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Text(value ? 'Вкл.' : 'Викл.'),
+      ],
+    );
+  }
+}

--- a/lib/src/ui/widgets/seller_profile_widgets/support/support_widget.dart
+++ b/lib/src/ui/widgets/seller_profile_widgets/support/support_widget.dart
@@ -7,17 +7,22 @@ class SupportWidget extends StatelessWidget {
 
   @override
   Widget build(context) {
-    return const SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          FaqsWidget(),
-          SizedBox(height: 34),
-          SupportFormWidget(),
-          SizedBox(
-            height: 16,
-          )
-        ],
+    return SingleChildScrollView(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          minHeight: MediaQuery.of(context).size.height,
+        ),
+        child: const IntrinsicHeight(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              FaqsWidget(),
+              SizedBox(height: 34),
+              SupportFormWidget(),
+              SizedBox(height: 16),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary by Sourcery

Add a full-featured settings page to the seller profile by creating AccountSettingsWidget and AccountSwitchWidget, integrate it into the main profile screen, and refine various UI components for consistent styling and layout.

New Features:
- Introduce AccountSettingsWidget with notification, theme, language toggles and account deletion action
- Add reusable AccountSwitchWidget for toggle controls

Enhancements:
- Integrate the new settings widget into SellerProfileScreen navigation
- Wrap support content in ConstrainedBox and IntrinsicHeight for full-height scrolling
- Adjust profile input field background to a lighter grey shade
- Set default text color on the change photo button to black