### PR TITLE
fix request

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_application_1/src/services/auth_storage.dart';
-import 'package:flutter_application_1/src/ui/screens/notFoundScreen/pageNotFoundScreen.dart';
+import 'package:flutter_application_1/src/ui/screens/notFoundScreen/page_not_found_screen.dart';
 import 'package:flutter_application_1/src/ui/screens/registration/registration_page.dart';
 import 'package:flutter_application_1/src/ui/screens/main/main_screen.dart';
 import 'package:flutter_application_1/src/ui/screens/welcome_page_screens/choose_role_screen.dart';

--- a/lib/src/services/auth_http_client.dart
+++ b/lib/src/services/auth_http_client.dart
@@ -1,0 +1,31 @@
+import 'package:http/http.dart' as http;
+import 'auth_storage.dart';
+import 'auth_service.dart';
+
+class AuthHttpClient extends http.BaseClient {
+  final http.Client _inner = http.Client();
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final accessToken = await AuthStorage.getAccessToken();
+
+    if (accessToken != null) {
+      request.headers['Authorization'] = 'Bearer $accessToken';
+    }
+
+    http.StreamedResponse response = await _inner.send(request);
+
+    if (response.statusCode == 401) {
+      final refreshed = await AuthService.refreshAccessToken();
+      if (refreshed) {
+        final newAccessToken = await AuthStorage.getAccessToken();
+        if (newAccessToken != null) {
+          request.headers['Authorization'] = 'Bearer $newAccessToken';
+          response = await _inner.send(request);
+        }
+      }
+    }
+
+    return response;
+  }
+}

--- a/lib/src/services/auth_storage.dart
+++ b/lib/src/services/auth_storage.dart
@@ -5,7 +5,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 class AuthStorage {
   static FlutterSecureStorage? _secureStorage;
   static SharedPreferences? _prefs;
-  static const _tokenKey = 'auth_token';
+  static const _accessTokenKey = 'access_token';
+  static const _refreshTokenKey = 'refresh_token';
 
   static Future<void> init() async {
     if (kIsWeb) {
@@ -15,28 +16,42 @@ class AuthStorage {
     }
   }
 
-  static Future<void> saveToken(String token) async {
+  static Future<void> saveAccessToken(String token) async {
     if (kIsWeb) {
-      await _prefs?.setString(_tokenKey, token);
+      await _prefs?.setString(_accessTokenKey, token);
     } else {
-      await _secureStorage?.write(key: _tokenKey, value: token);
-    }
-    print('Token saved: $token');
-  }
-
-  static Future<String?> getToken() async {
-    if (kIsWeb) {
-      return _prefs?.getString(_tokenKey);
-    } else {
-      return await _secureStorage?.read(key: _tokenKey);
+      await _secureStorage?.write(key: _accessTokenKey, value: token);
     }
   }
 
-  static Future<void> deleteToken() async {
+  static Future<void> saveRefreshToken(String token) async {
     if (kIsWeb) {
-      await _prefs?.remove(_tokenKey);
+      await _prefs?.setString(_refreshTokenKey, token);
     } else {
-      await _secureStorage?.delete(key: _tokenKey);
+      await _secureStorage?.write(key: _refreshTokenKey, value: token);
     }
+  }
+
+  static Future<String?> getAccessToken() async {
+    return kIsWeb
+        ? _prefs?.getString(_accessTokenKey)
+        : await _secureStorage?.read(key: _accessTokenKey);
+  }
+
+  static Future<String?> getRefreshToken() async {
+    return kIsWeb
+        ? _prefs?.getString(_refreshTokenKey)
+        : await _secureStorage?.read(key: _refreshTokenKey);
+  }
+
+  static Future<void> deleteTokens() async {
+    if (kIsWeb) {
+      await _prefs?.remove(_accessTokenKey);
+      await _prefs?.remove(_refreshTokenKey);
+    } else {
+      await _secureStorage?.delete(key: _accessTokenKey);
+      await _secureStorage?.delete(key: _refreshTokenKey);
+    }
+    print('Access & refresh tokens deleted');
   }
 }

--- a/lib/src/services/categories_service.dart
+++ b/lib/src/services/categories_service.dart
@@ -8,7 +8,7 @@ class CategoryService {
 
   // Utility function to retrieve the JWT token
   static Future<String> getAuthToken() async {
-    final token = await AuthStorage.getToken();
+    final token = await AuthStorage.getAccessToken();
     if (token == null || token.isEmpty) {
       throw Exception('JWT token is missing.');
     }

--- a/lib/src/services/listing_page_service.dart
+++ b/lib/src/services/listing_page_service.dart
@@ -43,7 +43,7 @@ class ListingPageService {
     String? gardenTypes,
   }) async {
     try {
-      final token = await AuthStorage.getToken();
+      final token = await AuthStorage.getAccessToken();
 
       var uri = Uri.parse('$_baseUrl/api/v1/products/create');
       var request = http.MultipartRequest('POST', uri);

--- a/lib/src/services/product_service.dart
+++ b/lib/src/services/product_service.dart
@@ -8,7 +8,7 @@ class ProductService {
       'http://ec2-18-197-114-210.eu-central-1.compute.amazonaws.com:8032';
 
   static Future<List<dynamic>> fetchProducts() async {
-    final token = await AuthStorage.getToken();
+    final token = await AuthStorage.getAccessToken();
     final url = Uri.parse('$_baseUrl/api/v1/products');
 
     // print('📡 Fetching products from $url');

--- a/lib/src/services/user_role_service.dart
+++ b/lib/src/services/user_role_service.dart
@@ -7,7 +7,7 @@ class UserRoleService {
       'http://ec2-18-197-114-210.eu-central-1.compute.amazonaws.com:8032';
 
   static Future<void> sendRole(Map<String, bool> role) async {
-    final token = await AuthStorage.getToken();
+    final token = await AuthStorage.getAccessToken();
     print('Retrieved token: $token');
     if (token == null || token.isEmpty) {
       throw Exception('Authorization token is missing');

--- a/lib/src/ui/screens/login/login_page.dart
+++ b/lib/src/ui/screens/login/login_page.dart
@@ -58,9 +58,13 @@ class _LoginPageState extends State<LoginPage> {
       final response = await AuthService.loginUser(email, password);
       LoadingDialog.hide(context);
 
-      if (response.containsKey('token')) {
-        final token = response['token'];
-        await AuthStorage.saveToken(token);
+      if (response.containsKey('access-token')) {
+        final accessToken = response['access-token'];
+        final refreshToken = response['refresh-token'];
+
+        print('TOKEN!! $accessToken');
+        await AuthStorage.saveAccessToken(accessToken);
+        await AuthStorage.saveRefreshToken(refreshToken);
 
         if (mounted) {
           Navigator.pushReplacementNamed(context, '/main');
@@ -75,8 +79,7 @@ class _LoginPageState extends State<LoginPage> {
     } catch (e) {
       LoadingDialog.hide(context);
       if (mounted) {
-        _showErrorDialog(
-            context, 'Щось пішло не так. Будь ласка, спробуйте пізніше.');
+        Navigator.pushReplacementNamed(context, '/notFoundScreen');
       }
     }
   }

--- a/lib/src/ui/screens/main/main_screen_desktop.dart
+++ b/lib/src/ui/screens/main/main_screen_desktop.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_application_1/src/ui/screens/main/sidebar_screens/listing_page.dart';
-import 'package:flutter_application_1/src/ui/screens/notFoundScreen/pageNotFoundScreen.dart';
+import 'package:flutter_application_1/src/ui/screens/notFoundScreen/page_not_found_screen.dart';
 import 'package:flutter_application_1/src/ui/screens/productDetailsScreen/product_details_screen.dart';
 import 'package:flutter_application_1/src/ui/screens/seller_profile/seller_profile_screen.dart';
 import 'package:flutter_application_1/src/ui/widgets/bread_crumb_navigation.dart';

--- a/lib/src/ui/screens/notFoundScreen/page_not_found_screen.dart
+++ b/lib/src/ui/screens/notFoundScreen/page_not_found_screen.dart
@@ -102,7 +102,7 @@ class _PageNotFoundScreenState extends State<PageNotFoundScreen> {
                     ),
                   ),
                   onPressed: () {
-                    Navigator.pushNamed(context, "/main");
+                    Navigator.pushNamed(context, "/");
                   },
                   child: const Text("На головну сторінку",
                       style: TextStyle(color: Colors.white, fontSize: 16)),

--- a/lib/src/ui/screens/registration/registration_page.dart
+++ b/lib/src/ui/screens/registration/registration_page.dart
@@ -32,8 +32,8 @@ class RegistrationPageState extends State<RegistrationPage> {
 
   Map<String, String> getFormData() {
     return {
-      "first_name": _firstNameController.text,
-      "last_name": _lastNameController.text,
+      "first-name": _firstNameController.text,
+      "last-name": _lastNameController.text,
       "email": _emailController.text,
       "password": _passwordController.text,
     };

--- a/lib/src/ui/widgets/main_screen_widgets/desktop/sidebar_desktop.dart
+++ b/lib/src/ui/widgets/main_screen_widgets/desktop/sidebar_desktop.dart
@@ -20,7 +20,7 @@ class _SidebarWidgetState extends State<SidebarWidget> {
 
   Future<void> _logout(BuildContext context) async {
     try {
-      await AuthStorage.deleteToken();
+      await AuthStorage.deleteTokens();
 
       Navigator.pushAndRemoveUntil(
         context,
@@ -33,7 +33,7 @@ class _SidebarWidgetState extends State<SidebarWidget> {
   }
 
   Future<bool> _isUserLoggedIn() async {
-    String? token = await AuthStorage.getToken();
+    String? token = await AuthStorage.getAccessToken();
     return token != null;
   }
 

--- a/lib/src/utils/auth_validator.dart
+++ b/lib/src/utils/auth_validator.dart
@@ -20,7 +20,7 @@ class _TokenBasedWidgetState extends State<TokenBasedWidget> {
   }
 
   Future<void> _checkToken() async {
-    final token = await AuthStorage.getToken();
+    final token = await AuthStorage.getAccessToken();
     setState(() {
       // hasToken = token != null && token.isNotEmpty;
       hasToken = token != null;


### PR DESCRIPTION
## Summary by Sourcery

Refactor the authentication flow to use separate access and refresh tokens with automatic refresh and retry logic, update token storage and usage across services and UI, and fix API URL and not-found screen routing.

New Features:
- Introduce refreshAccessToken method in AuthService to refresh access and refresh tokens
- Add AuthHttpClient to automatically inject and retry requests with Bearer tokens on 401 responses

Bug Fixes:
- Update base API URL to new EC2 instance
- Navigate to not-found screen on login failure and correct routing paths in NotFoundScreen imports

Enhancements:
- Split token storage into separate access and refresh tokens and update AuthStorage accordingly
- Update all service and UI components to use access and refresh tokens instead of a single auth token
- Modify registration form payload keys to use hyphenated first-name and last-name fields
- Clear both access and refresh tokens on logout

Chores:
- Rename NotFoundScreen file and update its imports