### PR TITLE
add en ua

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "603104015dd692ea3403755b55d07813d5cf8965"
+  revision: "6fba2447e95c451518584c35e25f5433f14d888c"
   channel: "stable"
 
 project_type: app
@@ -13,26 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 603104015dd692ea3403755b55d07813d5cf8965
-      base_revision: 603104015dd692ea3403755b55d07813d5cf8965
-    - platform: android
-      create_revision: 603104015dd692ea3403755b55d07813d5cf8965
-      base_revision: 603104015dd692ea3403755b55d07813d5cf8965
-    - platform: ios
-      create_revision: 603104015dd692ea3403755b55d07813d5cf8965
-      base_revision: 603104015dd692ea3403755b55d07813d5cf8965
-    - platform: linux
-      create_revision: 603104015dd692ea3403755b55d07813d5cf8965
-      base_revision: 603104015dd692ea3403755b55d07813d5cf8965
-    - platform: macos
-      create_revision: 603104015dd692ea3403755b55d07813d5cf8965
-      base_revision: 603104015dd692ea3403755b55d07813d5cf8965
+      create_revision: 6fba2447e95c451518584c35e25f5433f14d888c
+      base_revision: 6fba2447e95c451518584c35e25f5433f14d888c
     - platform: web
-      create_revision: 603104015dd692ea3403755b55d07813d5cf8965
-      base_revision: 603104015dd692ea3403755b55d07813d5cf8965
-    - platform: windows
-      create_revision: 603104015dd692ea3403755b55d07813d5cf8965
-      base_revision: 603104015dd692ea3403755b55d07813d5cf8965
+      create_revision: 6fba2447e95c451518584c35e25f5433f14d888c
+      base_revision: 6fba2447e95c451518584c35e25f5433f14d888c
 
   # User provided section
 

--- a/lib/src/localization/app_localizations.dart
+++ b/lib/src/localization/app_localizations.dart
@@ -87,6 +87,11 @@ class AppLocalizations {
   String get enterPasswordAgain => _localizedValues[locale.languageCode]!['enter_password_again']!;
   String get repeatPassword => _localizedValues[locale.languageCode]!['repeat_password']!;
   String get alreadyHaveAccount => _localizedValues[locale.languageCode]!['already_have_account']!;
+  
+  // === ВХІД ===
+  String get signInAccount => _localizedValues[locale.languageCode]!['sign_in_account']!;
+  String get welcomeBack => _localizedValues[locale.languageCode]!['welcome_back']!;
+  String get dontHaveAccount => _localizedValues[locale.languageCode]!['dont_have_account']!;
 
   /// Словник перекладів
   static const Map<String, Map<String, String>> _localizedValues = {
@@ -146,6 +151,11 @@ class AppLocalizations {
       'enter_password_again': 'Введіть пароль повторно',
       'repeat_password': 'Повторіть пароль',
       'already_have_account': 'Вже маєте акаунт?',
+      
+      // Вхід
+      'sign_in_account': 'Увійти в акаунт',
+      'welcome_back': 'Вітаємо знову у Shum!',
+      'dont_have_account': 'Ще не маєте акаунт?',
     },
     'en': {
       // General
@@ -203,6 +213,11 @@ class AppLocalizations {
       'enter_password_again': 'Enter password again',
       'repeat_password': 'Repeat password',
       'already_have_account': 'Already have an account?',
+      
+      // Sign In
+      'sign_in_account': 'Sign In to Account',
+      'welcome_back': 'Welcome back to Shum!',
+      'dont_have_account': 'Don\'t have an account?',
     },
   };
 }

--- a/lib/src/localization/app_localizations.dart
+++ b/lib/src/localization/app_localizations.dart
@@ -85,6 +85,8 @@ class AppLocalizations {
   String get enterEmail => _localizedValues[locale.languageCode]!['enter_email']!;
   String get enterPassword => _localizedValues[locale.languageCode]!['enter_password']!;
   String get enterPasswordAgain => _localizedValues[locale.languageCode]!['enter_password_again']!;
+  String get repeatPassword => _localizedValues[locale.languageCode]!['repeat_password']!;
+  String get alreadyHaveAccount => _localizedValues[locale.languageCode]!['already_have_account']!;
 
   /// Словник перекладів
   static const Map<String, Map<String, String>> _localizedValues = {
@@ -142,6 +144,8 @@ class AppLocalizations {
       'enter_email': 'Введіть пошту',
       'enter_password': 'Введіть пароль',
       'enter_password_again': 'Введіть пароль повторно',
+      'repeat_password': 'Повторіть пароль',
+      'already_have_account': 'Вже маєте акаунт?',
     },
     'en': {
       // General
@@ -157,7 +161,7 @@ class AppLocalizations {
       'home': 'Home',
       'about': 'About',
       'sign_up': 'Sign Up',
-      'sign_in': 'Sign In',
+      'sign_in': 'Log In',
       'logout': 'Logout',
 
       // Forms
@@ -182,10 +186,10 @@ class AppLocalizations {
       'profile': 'Profile',
 
       // Welcome screen
-      'welcome_title': 'Hello!',
-      'welcome_subtitle': 'Get a secure shopping experience\n with us',
+      'welcome_title': 'Welcome!',
+      'welcome_subtitle': 'Get a safe shopping experience \n with us',
       'get_started': 'Get Started',
-      'skip_step': 'Skip this step',
+      'skip_step': 'Skip for now',
       'download_app': 'Download App',
       
       // Registration
@@ -197,6 +201,8 @@ class AppLocalizations {
       'enter_email': 'Enter email',
       'enter_password': 'Enter password',
       'enter_password_again': 'Enter password again',
+      'repeat_password': 'Repeat password',
+      'already_have_account': 'Already have an account?',
     },
   };
 }

--- a/lib/src/localization/app_localizations.dart
+++ b/lib/src/localization/app_localizations.dart
@@ -113,6 +113,9 @@ class AppLocalizations {
   String get questions => _localizedValues[locale.languageCode]!['questions']!;
   String get favorites => _localizedValues[locale.languageCode]!['favorites']!;
   String get support => _localizedValues[locale.languageCode]!['support']!;
+  
+  // === REGISTRATION PAGE ===
+  String get registrationSubtitle => _localizedValues[locale.languageCode]!['registration_subtitle']!;
 
   /// Словник перекладів
   static const Map<String, Map<String, String>> _localizedValues = {
@@ -198,6 +201,9 @@ class AppLocalizations {
       'questions': 'Питання',
       'favorites': 'Обране',
       'support': 'Підтримка',
+      
+      // Registration
+      'registration_subtitle': 'Отримайте більше можливостей\nстворивши акаунт',
     },
     'en': {
       // General
@@ -281,6 +287,9 @@ class AppLocalizations {
       'questions': 'Questions',
       'favorites': 'Favorites',
       'support': 'Support',
+      
+      // Registration
+      'registration_subtitle': 'Get more opportunities\nby creating an account',
     },
   };
 }

--- a/lib/src/localization/app_localizations.dart
+++ b/lib/src/localization/app_localizations.dart
@@ -71,6 +71,20 @@ class AppLocalizations {
       _localizedValues[locale.languageCode]!['welcome_subtitle']!;
   String get getStarted =>
       _localizedValues[locale.languageCode]!['get_started']!;
+  String get skipStep =>
+      _localizedValues[locale.languageCode]!['skip_step']!;
+  String get downloadApp =>
+      _localizedValues[locale.languageCode]!['download_app']!;
+  
+  // === РЕЄСТРАЦІЯ ===
+  String get yourName => _localizedValues[locale.languageCode]!['your_name']!;
+  String get yourSurname => _localizedValues[locale.languageCode]!['your_surname']!;
+  String get yourEmail => _localizedValues[locale.languageCode]!['your_email']!;
+  String get enterName => _localizedValues[locale.languageCode]!['enter_name']!;
+  String get enterSurname => _localizedValues[locale.languageCode]!['enter_surname']!;
+  String get enterEmail => _localizedValues[locale.languageCode]!['enter_email']!;
+  String get enterPassword => _localizedValues[locale.languageCode]!['enter_password']!;
+  String get enterPasswordAgain => _localizedValues[locale.languageCode]!['enter_password_again']!;
 
   /// Словник перекладів
   static const Map<String, Map<String, String>> _localizedValues = {
@@ -113,9 +127,21 @@ class AppLocalizations {
       'profile': 'Профіль',
 
       // Вітальний екран
-      'welcome_title': 'Ласкаво просимо до SHUM',
-      'welcome_subtitle': 'Ваш новий маркетплейс',
+      'welcome_title': 'Привіт!',
+      'welcome_subtitle': 'Отримай безпечний досвід покупок\n разом з нами',
       'get_started': 'Почати',
+      'skip_step': 'Пропустити цей крок',
+      'download_app': 'Завантажити застосунок',
+      
+      // Реєстрація
+      'your_name': 'Ваше ім\'я',
+      'your_surname': 'Ваше прізвище', 
+      'your_email': 'Ваша пошта',
+      'enter_name': 'Введіть ім\'я',
+      'enter_surname': 'Введіть прізвище',
+      'enter_email': 'Введіть пошту',
+      'enter_password': 'Введіть пароль',
+      'enter_password_again': 'Введіть пароль повторно',
     },
     'en': {
       // General
@@ -156,9 +182,21 @@ class AppLocalizations {
       'profile': 'Profile',
 
       // Welcome screen
-      'welcome_title': 'Welcome to SHUM',
-      'welcome_subtitle': 'Your new marketplace',
+      'welcome_title': 'Hello!',
+      'welcome_subtitle': 'Get a secure shopping experience\n with us',
       'get_started': 'Get Started',
+      'skip_step': 'Skip this step',
+      'download_app': 'Download App',
+      
+      // Registration
+      'your_name': 'Your Name',
+      'your_surname': 'Your Surname',
+      'your_email': 'Your Email',
+      'enter_name': 'Enter name',
+      'enter_surname': 'Enter surname',
+      'enter_email': 'Enter email',
+      'enter_password': 'Enter password',
+      'enter_password_again': 'Enter password again',
     },
   };
 }

--- a/lib/src/localization/app_localizations.dart
+++ b/lib/src/localization/app_localizations.dart
@@ -71,51 +71,64 @@ class AppLocalizations {
       _localizedValues[locale.languageCode]!['welcome_subtitle']!;
   String get getStarted =>
       _localizedValues[locale.languageCode]!['get_started']!;
-  String get skipStep =>
-      _localizedValues[locale.languageCode]!['skip_step']!;
+  String get skipStep => _localizedValues[locale.languageCode]!['skip_step']!;
   String get downloadApp =>
       _localizedValues[locale.languageCode]!['download_app']!;
-  
+
   // === РЕЄСТРАЦІЯ ===
   String get yourName => _localizedValues[locale.languageCode]!['your_name']!;
-  String get yourSurname => _localizedValues[locale.languageCode]!['your_surname']!;
+  String get yourSurname =>
+      _localizedValues[locale.languageCode]!['your_surname']!;
   String get yourEmail => _localizedValues[locale.languageCode]!['your_email']!;
   String get enterName => _localizedValues[locale.languageCode]!['enter_name']!;
-  String get enterSurname => _localizedValues[locale.languageCode]!['enter_surname']!;
-  String get enterEmail => _localizedValues[locale.languageCode]!['enter_email']!;
-  String get enterPassword => _localizedValues[locale.languageCode]!['enter_password']!;
-  String get enterPasswordAgain => _localizedValues[locale.languageCode]!['enter_password_again']!;
-  String get repeatPassword => _localizedValues[locale.languageCode]!['repeat_password']!;
-  String get alreadyHaveAccount => _localizedValues[locale.languageCode]!['already_have_account']!;
-  
+  String get enterSurname =>
+      _localizedValues[locale.languageCode]!['enter_surname']!;
+  String get enterEmail =>
+      _localizedValues[locale.languageCode]!['enter_email']!;
+  String get enterPassword =>
+      _localizedValues[locale.languageCode]!['enter_password']!;
+  String get enterPasswordAgain =>
+      _localizedValues[locale.languageCode]!['enter_password_again']!;
+  String get repeatPassword =>
+      _localizedValues[locale.languageCode]!['repeat_password']!;
+  String get alreadyHaveAccount =>
+      _localizedValues[locale.languageCode]!['already_have_account']!;
+
   // === ВХІД ===
-  String get signInAccount => _localizedValues[locale.languageCode]!['sign_in_account']!;
-  String get welcomeBack => _localizedValues[locale.languageCode]!['welcome_back']!;
-  String get dontHaveAccount => _localizedValues[locale.languageCode]!['dont_have_account']!;
-  
+  String get signInAccount =>
+      _localizedValues[locale.languageCode]!['sign_in_account']!;
+  String get welcomeBack =>
+      _localizedValues[locale.languageCode]!['welcome_back']!;
+  String get dontHaveAccount =>
+      _localizedValues[locale.languageCode]!['dont_have_account']!;
+
   // === НАВІГАЦІЯ ===
   String get search => _localizedValues[locale.languageCode]!['search']!;
   String get sell => _localizedValues[locale.languageCode]!['sell']!;
   String get chat => _localizedValues[locale.languageCode]!['chat']!;
   String get account => _localizedValues[locale.languageCode]!['account']!;
-  
+
   // === FOOTER SECTIONS ===
   String get pages => _localizedValues[locale.languageCode]!['pages']!;
   String get other => _localizedValues[locale.languageCode]!['other']!;
   String get contacts => _localizedValues[locale.languageCode]!['contacts']!;
-  String get seasonalOffers => _localizedValues[locale.languageCode]!['seasonal_offers']!;
+  String get seasonalOffers =>
+      _localizedValues[locale.languageCode]!['seasonal_offers']!;
   String get newAds => _localizedValues[locale.languageCode]!['new_ads']!;
-  String get notifications => _localizedValues[locale.languageCode]!['notifications']!;
+  String get notifications =>
+      _localizedValues[locale.languageCode]!['notifications']!;
   String get reviews => _localizedValues[locale.languageCode]!['reviews']!;
-  String get recommendedProducts => _localizedValues[locale.languageCode]!['recommended_products']!;
+  String get recommendedProducts =>
+      _localizedValues[locale.languageCode]!['recommended_products']!;
   String get history => _localizedValues[locale.languageCode]!['history']!;
   String get delivery => _localizedValues[locale.languageCode]!['delivery']!;
   String get questions => _localizedValues[locale.languageCode]!['questions']!;
   String get favorites => _localizedValues[locale.languageCode]!['favorites']!;
   String get support => _localizedValues[locale.languageCode]!['support']!;
-  
+
   // === REGISTRATION PAGE ===
-  String get registrationSubtitle => _localizedValues[locale.languageCode]!['registration_subtitle']!;
+  String get registrationSubtitle =>
+      _localizedValues[locale.languageCode]!['registration_subtitle']!;
 
   /// Словник перекладів
   static const Map<String, Map<String, String>> _localizedValues = {
@@ -163,10 +176,10 @@ class AppLocalizations {
       'get_started': 'Почати',
       'skip_step': 'Пропустити цей крок',
       'download_app': 'Завантажити застосунок',
-      
+
       // Реєстрація
       'your_name': 'Ваше ім\'я',
-      'your_surname': 'Ваше прізвище', 
+      'your_surname': 'Ваше прізвище',
       'your_email': 'Ваша пошта',
       'enter_name': 'Введіть ім\'я',
       'enter_surname': 'Введіть прізвище',
@@ -175,18 +188,18 @@ class AppLocalizations {
       'enter_password_again': 'Введіть пароль повторно',
       'repeat_password': 'Повторіть пароль',
       'already_have_account': 'Вже маєте акаунт?',
-      
+
       // Вхід
       'sign_in_account': 'Увійти в акаунт',
       'welcome_back': 'Вітаємо знову у Shum!',
       'dont_have_account': 'Ще не маєте акаунт?',
-      
+
       // Навігація
       'search': 'Пошук',
       'sell': 'Продати',
       'chat': 'Чат',
       'account': 'Акаунт',
-      
+
       // Footer Sections
       'pages': 'Сторінки',
       'other': 'Інше',
@@ -201,7 +214,7 @@ class AppLocalizations {
       'questions': 'Питання',
       'favorites': 'Обране',
       'support': 'Підтримка',
-      
+
       // Registration
       'registration_subtitle': 'Отримайте більше можливостей\nстворивши акаунт',
     },
@@ -249,7 +262,7 @@ class AppLocalizations {
       'get_started': 'Get Started',
       'skip_step': 'Skip for now',
       'download_app': 'Download App',
-      
+
       // Registration
       'your_name': 'Your Name',
       'your_surname': 'Your Surname',
@@ -260,19 +273,19 @@ class AppLocalizations {
       'enter_password': 'Enter password',
       'enter_password_again': 'Enter password again',
       'repeat_password': 'Repeat password',
-      'already_have_account': 'Already have an account?',
-      
+      'already_have_account': 'Have an account?',
+
       // Sign In
       'sign_in_account': 'Sign In to Account',
       'welcome_back': 'Welcome back to Shum!',
       'dont_have_account': 'Don\'t have an account?',
-      
+
       // Navigation
       'search': 'Search',
       'sell': 'Sell',
       'chat': 'Chat',
       'account': 'Account',
-      
+
       // Footer Sections
       'pages': 'Pages',
       'other': 'Other',
@@ -287,9 +300,9 @@ class AppLocalizations {
       'questions': 'Questions',
       'favorites': 'Favorites',
       'support': 'Support',
-      
+
       // Registration
-      'registration_subtitle': 'Get more opportunities\nby creating an account',
+      'registration_subtitle': 'Get more features by creating an account',
     },
   };
 }

--- a/lib/src/localization/app_localizations.dart
+++ b/lib/src/localization/app_localizations.dart
@@ -92,6 +92,12 @@ class AppLocalizations {
   String get signInAccount => _localizedValues[locale.languageCode]!['sign_in_account']!;
   String get welcomeBack => _localizedValues[locale.languageCode]!['welcome_back']!;
   String get dontHaveAccount => _localizedValues[locale.languageCode]!['dont_have_account']!;
+  
+  // === НАВІГАЦІЯ ===
+  String get search => _localizedValues[locale.languageCode]!['search']!;
+  String get sell => _localizedValues[locale.languageCode]!['sell']!;
+  String get chat => _localizedValues[locale.languageCode]!['chat']!;
+  String get account => _localizedValues[locale.languageCode]!['account']!;
 
   /// Словник перекладів
   static const Map<String, Map<String, String>> _localizedValues = {
@@ -156,6 +162,12 @@ class AppLocalizations {
       'sign_in_account': 'Увійти в акаунт',
       'welcome_back': 'Вітаємо знову у Shum!',
       'dont_have_account': 'Ще не маєте акаунт?',
+      
+      // Навігація
+      'search': 'Пошук',
+      'sell': 'Продати',
+      'chat': 'Чат',
+      'account': 'Акаунт',
     },
     'en': {
       // General
@@ -218,6 +230,12 @@ class AppLocalizations {
       'sign_in_account': 'Sign In to Account',
       'welcome_back': 'Welcome back to Shum!',
       'dont_have_account': 'Don\'t have an account?',
+      
+      // Navigation
+      'search': 'Search',
+      'sell': 'Sell',
+      'chat': 'Chat',
+      'account': 'Account',
     },
   };
 }

--- a/lib/src/localization/app_localizations.dart
+++ b/lib/src/localization/app_localizations.dart
@@ -98,6 +98,21 @@ class AppLocalizations {
   String get sell => _localizedValues[locale.languageCode]!['sell']!;
   String get chat => _localizedValues[locale.languageCode]!['chat']!;
   String get account => _localizedValues[locale.languageCode]!['account']!;
+  
+  // === FOOTER SECTIONS ===
+  String get pages => _localizedValues[locale.languageCode]!['pages']!;
+  String get other => _localizedValues[locale.languageCode]!['other']!;
+  String get contacts => _localizedValues[locale.languageCode]!['contacts']!;
+  String get seasonalOffers => _localizedValues[locale.languageCode]!['seasonal_offers']!;
+  String get newAds => _localizedValues[locale.languageCode]!['new_ads']!;
+  String get notifications => _localizedValues[locale.languageCode]!['notifications']!;
+  String get reviews => _localizedValues[locale.languageCode]!['reviews']!;
+  String get recommendedProducts => _localizedValues[locale.languageCode]!['recommended_products']!;
+  String get history => _localizedValues[locale.languageCode]!['history']!;
+  String get delivery => _localizedValues[locale.languageCode]!['delivery']!;
+  String get questions => _localizedValues[locale.languageCode]!['questions']!;
+  String get favorites => _localizedValues[locale.languageCode]!['favorites']!;
+  String get support => _localizedValues[locale.languageCode]!['support']!;
 
   /// Словник перекладів
   static const Map<String, Map<String, String>> _localizedValues = {
@@ -168,6 +183,21 @@ class AppLocalizations {
       'sell': 'Продати',
       'chat': 'Чат',
       'account': 'Акаунт',
+      
+      // Footer Sections
+      'pages': 'Сторінки',
+      'other': 'Інше',
+      'contacts': 'Контакти',
+      'seasonal_offers': 'Сезонні пропозиції',
+      'new_ads': 'Нові оголошення',
+      'notifications': 'Сповіщення',
+      'reviews': 'Відгуки',
+      'recommended_products': 'Рекомендовані товари',
+      'history': 'Історія',
+      'delivery': 'Доставка та оплата',
+      'questions': 'Питання',
+      'favorites': 'Обране',
+      'support': 'Підтримка',
     },
     'en': {
       // General
@@ -236,6 +266,21 @@ class AppLocalizations {
       'sell': 'Sell',
       'chat': 'Chat',
       'account': 'Account',
+      
+      // Footer Sections
+      'pages': 'Pages',
+      'other': 'Other',
+      'contacts': 'Contacts',
+      'seasonal_offers': 'Seasonal Offers',
+      'new_ads': 'New Ads',
+      'notifications': 'Notifications',
+      'reviews': 'Reviews',
+      'recommended_products': 'Recommended Products',
+      'history': 'History',
+      'delivery': 'Delivery & Payment',
+      'questions': 'Questions',
+      'favorites': 'Favorites',
+      'support': 'Support',
     },
   };
 }

--- a/lib/src/ui/screens/registration/registration_page.dart
+++ b/lib/src/ui/screens/registration/registration_page.dart
@@ -163,7 +163,7 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
               children: [
                 const SizedBox(height: 76),
                 Text(
-                  'Реєстрація',
+                  l10n.signUp,
                   textAlign: TextAlign.center,
                   style: Theme.of(context)
                       .textTheme
@@ -181,30 +181,30 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                   key: _formKey,
                   child: Column(
                     children: [
-                      AuthField(
+                        labelText: l10n.yourName,
                         labelText: 'Ваше ім’я',
                         validator: validateName,
                         controller: _firstNameController,
-                        hintText: "Введіть ім'я",
+                        hintText: l10n.enterName,
                         showSuffixIcon: (text) {
                           return validateName(text) == null;
                         },
                       ),
                       const SizedBox(height: 12),
                       AuthField(
-                        labelText: 'Ваше прізвище',
+                        labelText: l10n.yourSurname,
                         validator: validateName,
                         controller: _lastNameController,
-                        hintText: "Введіть прізвище",
+                        hintText: l10n.enterSurname,
                         showSuffixIcon: (text) {
                           return validateName(text) == null;
                         },
                       ),
                       const SizedBox(height: 12),
                       AuthField(
-                        labelText: 'Ваша пошта',
+                        labelText: l10n.yourEmail,
                         controller: _emailController,
-                        hintText: 'Введіть пошту',
+                        hintText: l10n.enterEmail,
                         validator: validateEmail,
                         showSuffixIcon: (text) {
                           return validateEmail(text) == null;
@@ -213,20 +213,20 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                       ),
                       const SizedBox(height: 12),
                       AuthField(
-                        labelText: 'Пароль',
+                        labelText: l10n.password,
                         controller: _passwordController,
-                        hintText: 'Введіть пароль',
+                        hintText: l10n.enterPassword,
                         validator: validatePassword,
                         showCounter: true,
                         isObscureText: true,
                       ),
                       AuthField(
-                        labelText: 'Повторіть пароль',
+                        labelText: l10n.repeatPassword,
                         controller: _confirmPasswordController,
-                        hintText: 'Введіть пароль повторно',
+                        hintText: l10n.enterPasswordAgain,
                         validator: (value) {
                           if (value != _passwordController.text) {
-                            return 'Паролі не співпадають';
+                            return l10n.passwordsDoNotMatch;
                           }
                           return validatePassword(value);
                         },
@@ -235,7 +235,7 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                       ),
                       const SizedBox(height: 40),
                       AuthButton(
-                        text: 'Зареєструватися',
+                        text: l10n.register,
                         isButtonDisabled: _isButtonDisabled,
                         onPressed: () {
                           _firstNameController.text =
@@ -264,10 +264,10 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                             style: Theme.of(context).textTheme.bodyMedium,
                             children: const [
                               TextSpan(
-                                text: 'Вже маєте акаунт? ',
+                                text: l10n.alreadyHaveAccount + ' ',
                               ),
                               TextSpan(
-                                text: 'Увійти',
+                                text: l10n.signIn,
                                 style: TextStyle(
                                   color: TColors.orange,
                                 ),

--- a/lib/src/ui/screens/registration/registration_page.dart
+++ b/lib/src/ui/screens/registration/registration_page.dart
@@ -124,7 +124,6 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
     return Scaffold(
       body: Center(
         child: ConstrainedBox(
@@ -163,7 +162,7 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
               children: [
                 const SizedBox(height: 76),
                 Text(
-                  l10n.signUp,
+                  'Реєстрація',
                   textAlign: TextAlign.center,
                   style: Theme.of(context)
                       .textTheme

--- a/lib/src/ui/screens/registration/registration_page.dart
+++ b/lib/src/ui/screens/registration/registration_page.dart
@@ -162,7 +162,7 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
               children: [
                 const SizedBox(height: 76),
                 Text(
-                  'Реєстрація',
+                  AppLocalizations.of(context).signUp,
                   textAlign: TextAlign.center,
                   style: Theme.of(context)
                       .textTheme
@@ -171,7 +171,7 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Отримайте більше можливостей\nстворивши акаунт',
+                  AppLocalizations.of(context).registrationSubtitle,
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.titleMedium,
                 ),
@@ -234,7 +234,7 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                       ),
                       const SizedBox(height: 40),
                       AuthButton(
-                        text: 'Зареєструватися',
+                        text: AppLocalizations.of(context).signUp,
                         isButtonDisabled: _isButtonDisabled,
                         onPressed: () {
                           _firstNameController.text =
@@ -261,13 +261,13 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                         child: RichText(
                           text: TextSpan(
                             style: Theme.of(context).textTheme.bodyMedium,
-                            children: const [
+                            children: [
                               TextSpan(
-                                text: 'Вже маєте акаунт? ',
+                                text: AppLocalizations.of(context).alreadyHaveAccount,
                               ),
                               TextSpan(
-                                text: 'Увійти',
-                                style: TextStyle(
+                                text: AppLocalizations.of(context).signIn,
+                                style: const TextStyle(
                                   color: TColors.orange,
                                 ),
                               ),

--- a/lib/src/ui/screens/registration/registration_page.dart
+++ b/lib/src/ui/screens/registration/registration_page.dart
@@ -263,7 +263,8 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                             style: Theme.of(context).textTheme.bodyMedium,
                             children: [
                               TextSpan(
-                                text: AppLocalizations.of(context).alreadyHaveAccount,
+                                text: AppLocalizations.of(context)
+                                    .alreadyHaveAccount,
                               ),
                               TextSpan(
                                 text: AppLocalizations.of(context).signIn,

--- a/lib/src/ui/screens/registration/registration_page.dart
+++ b/lib/src/ui/screens/registration/registration_page.dart
@@ -181,30 +181,30 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                   key: _formKey,
                   child: Column(
                     children: [
-                        labelText: l10n.yourName,
+                      AuthField(
                         labelText: 'Ваше ім’я',
                         validator: validateName,
                         controller: _firstNameController,
-                        hintText: l10n.enterName,
+                        hintText: "Введіть ім'я",
                         showSuffixIcon: (text) {
                           return validateName(text) == null;
                         },
                       ),
                       const SizedBox(height: 12),
                       AuthField(
-                        labelText: l10n.yourSurname,
+                        labelText: 'Ваше прізвище',
                         validator: validateName,
                         controller: _lastNameController,
-                        hintText: l10n.enterSurname,
+                        hintText: "Введіть прізвище",
                         showSuffixIcon: (text) {
                           return validateName(text) == null;
                         },
                       ),
                       const SizedBox(height: 12),
                       AuthField(
-                        labelText: l10n.yourEmail,
+                        labelText: 'Ваша пошта',
                         controller: _emailController,
-                        hintText: l10n.enterEmail,
+                        hintText: 'Введіть пошту',
                         validator: validateEmail,
                         showSuffixIcon: (text) {
                           return validateEmail(text) == null;
@@ -213,20 +213,20 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                       ),
                       const SizedBox(height: 12),
                       AuthField(
-                        labelText: l10n.password,
+                        labelText: 'Пароль',
                         controller: _passwordController,
-                        hintText: l10n.enterPassword,
+                        hintText: 'Введіть пароль',
                         validator: validatePassword,
                         showCounter: true,
                         isObscureText: true,
                       ),
                       AuthField(
-                        labelText: l10n.repeatPassword,
+                        labelText: 'Повторіть пароль',
                         controller: _confirmPasswordController,
-                        hintText: l10n.enterPasswordAgain,
+                        hintText: 'Введіть пароль повторно',
                         validator: (value) {
                           if (value != _passwordController.text) {
-                            return l10n.passwordsDoNotMatch;
+                            return 'Паролі не співпадають';
                           }
                           return validatePassword(value);
                         },
@@ -235,7 +235,7 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                       ),
                       const SizedBox(height: 40),
                       AuthButton(
-                        text: l10n.register,
+                        text: 'Зареєструватися',
                         isButtonDisabled: _isButtonDisabled,
                         onPressed: () {
                           _firstNameController.text =
@@ -264,10 +264,10 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
                             style: Theme.of(context).textTheme.bodyMedium,
                             children: const [
                               TextSpan(
-                                text: l10n.alreadyHaveAccount + ' ',
+                                text: 'Вже маєте акаунт? ',
                               ),
                               TextSpan(
-                                text: l10n.signIn,
+                                text: 'Увійти',
                                 style: TextStyle(
                                   color: TColors.orange,
                                 ),

--- a/lib/src/ui/screens/registration/registration_page.dart
+++ b/lib/src/ui/screens/registration/registration_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_application_1/constants/colors.dart';
 import 'package:flutter_application_1/src/ui/screens/login/login_page.dart';
 import 'package:flutter_application_1/src/ui/widgets/shared_widgets/language_selector.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../localization/app_localizations.dart';
 
 import '../../../exceptions/email_already_registered_exception.dart';
 import '../../../services/auth_service.dart';
@@ -11,14 +13,14 @@ import '../../widgets/auth_widgets/auth_field.dart';
 import '../../../utils/validators.dart';
 import '../../widgets/loading_dialog.dart';
 
-class RegistrationPage extends StatefulWidget {
+class RegistrationPage extends ConsumerStatefulWidget {
   const RegistrationPage({super.key});
 
   @override
   RegistrationPageState createState() => RegistrationPageState();
 }
 
-class RegistrationPageState extends State<RegistrationPage> {
+class RegistrationPageState extends ConsumerState<RegistrationPage> {
   String? _emailError;
   final _formKey = GlobalKey<FormState>();
 
@@ -122,6 +124,7 @@ class RegistrationPageState extends State<RegistrationPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
       body: Center(
         child: ConstrainedBox(

--- a/lib/src/ui/screens/registration/registration_page_backup.dart
+++ b/lib/src/ui/screens/registration/registration_page_backup.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_application_1/constants/colors.dart';
+import 'package:flutter_application_1/src/ui/screens/login/login_page.dart';
+import 'package:flutter_application_1/src/ui/widgets/shared_widgets/language_selector.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../localization/app_localizations.dart';
+
+import '../../../exceptions/email_already_registered_exception.dart';
+import '../../../services/auth_service.dart';
+
+import '../../widgets/auth_widgets/auth_button.dart';
+import '../../widgets/auth_widgets/auth_field.dart';
+import '../../../utils/validators.dart';
+import '../../widgets/loading_dialog.dart';
+
+class RegistrationPage extends ConsumerStatefulWidget {
+  const RegistrationPage({super.key});
+
+  @override
+  RegistrationPageState createState() => RegistrationPageState();
+}
+
+class RegistrationPageState extends ConsumerState<RegistrationPage> {
+  String? _emailError;
+  final _formKey = GlobalKey<FormState>();
+
+  final TextEditingController _firstNameController = TextEditingController();
+  final TextEditingController _lastNameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmPasswordController =
+      TextEditingController();
+  bool _isButtonDisabled = true;
+
+  Map<String, String> getFormData() {
+    return {
+      "first_name": _firstNameController.text,
+      "last_name": _lastNameController.text,
+      "email": _emailController.text,
+      "password": _passwordController.text,
+    };
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _firstNameController.addListener(_checkFormFilled);
+    _lastNameController.addListener(_checkFormFilled);
+    _emailController.addListener(_checkFormFilled);
+    _passwordController.addListener(_checkFormFilled);
+    _confirmPasswordController.addListener(_checkFormFilled);
+  }
+
+  @override
+  void dispose() {
+    _firstNameController.dispose();
+    _lastNameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  void _checkFormFilled() {
+    final isFormFilled = _firstNameController.text.isNotEmpty &&
+        _lastNameController.text.isNotEmpty &&
+        _emailController.text.isNotEmpty &&
+        _passwordController.text.isNotEmpty &&
+        _confirmPasswordController.text.isNotEmpty;
+
+    setState(() {
+      _isButtonDisabled = !isFormFilled;
+    });
+  }
+
+  Future<void> registerUser(BuildContext context) async {
+    if (_formKey.currentState?.validate() ?? false) {
+      final formData = getFormData();
+      LoadingDialog.show(context);
+      try {
+        await AuthService.registerUser(formData);
+        LoadingDialog.hide(context);
+
+        if (mounted) {
+          Navigator.pushReplacementNamed(context, '/greeting');
+        }
+      } catch (e, stackTrace) {
+        LoadingDialog.hide(context);
+        print('Caught error: $e');
+        print('Stack trace: $stackTrace');
+
+        showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Помилка'),
+            content: SingleChildScrollView(
+              child: Text('$e\n\n$stackTrace'),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+
+        if (e is EmailAlreadyRegisteredException) {
+          setState(() {
+            _emailError = 'Ця пошта вже використовується';
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(e.message)),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Сталася помилка. Спробуйте ще раз.')),
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: 1440,
+          ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              if (constraints.maxWidth < 600) {
+                return _buildMobileLayout(Theme.of(context).textTheme);
+              } else {
+                return _buildDesktopLayout(Theme.of(context).textTheme);
+              }
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMobileLayout(TextTheme textTheme) {
+    return SafeArea(
+      child: Scaffold(
+        extendBodyBehindAppBar: true,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          scrolledUnderElevation: 0,
+          actions: const [
+            LanguageSelector(),
+          ],
+        ),
+        body: Center(
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                const SizedBox(height: 76),
+                Text(
+                  'Реєстрація',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleLarge
+                      ?.copyWith(fontSize: 32),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Отримайте більше можливостей\nстворивши акаунт',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 48),
+                Form(
+                  key: _formKey,
+                  child: Column(
+                    children: [
+                      AuthField(
+                        labelText: 'Ваше ім’я',
+                        validator: validateName,
+                        controller: _firstNameController,
+                        hintText: "Введіть ім'я",
+                        showSuffixIcon: (text) {
+                          return validateName(text) == null;
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      AuthField(
+                        labelText: 'Ваше прізвище',
+                        validator: validateName,
+                        controller: _lastNameController,
+                        hintText: "Введіть прізвище",
+                        showSuffixIcon: (text) {
+                          return validateName(text) == null;
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      AuthField(
+                        labelText: 'Ваша пошта',
+                        controller: _emailController,
+                        hintText: 'Введіть пошту',
+                        validator: validateEmail,
+                        showSuffixIcon: (text) {
+                          return validateEmail(text) == null;
+                        },
+                        errorText: _emailError,
+                      ),
+                      const SizedBox(height: 12),
+                      AuthField(
+                        labelText: 'Пароль',
+                        controller: _passwordController,
+                        hintText: 'Введіть пароль',
+                        validator: validatePassword,
+                        showCounter: true,
+                        isObscureText: true,
+                      ),
+                      AuthField(
+                        labelText: 'Повторіть пароль',
+                        controller: _confirmPasswordController,
+                        hintText: 'Введіть пароль повторно',
+                        validator: (value) {
+                          if (value != _passwordController.text) {
+                            return 'Паролі не співпадають';
+                          }
+                          return validatePassword(value);
+                        },
+                        showCounter: true,
+                        isObscureText: true,
+                      ),
+                      const SizedBox(height: 40),
+                      AuthButton(
+                        text: 'Зареєструватися',
+                        isButtonDisabled: _isButtonDisabled,
+                        onPressed: () {
+                          _firstNameController.text =
+                              _firstNameController.text.replaceAll(' ', '');
+                          _lastNameController.text =
+                              _lastNameController.text.replaceAll(' ', '');
+                          registerUser(context);
+                        },
+                      ),
+                      TextButton(
+                        style: ButtonStyle(
+                          overlayColor:
+                              WidgetStateProperty.all(Colors.transparent),
+                          padding: WidgetStateProperty.all(EdgeInsets.zero),
+                        ),
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => const LoginPage(),
+                            ),
+                          );
+                        },
+                        child: RichText(
+                          text: TextSpan(
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            children: const [
+                              TextSpan(
+                                text: 'Вже маєте акаунт? ',
+                              ),
+                              TextSpan(
+                                text: 'Увійти',
+                                style: TextStyle(
+                                  color: TColors.orange,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      )
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDesktopLayout(TextTheme textTheme) {
+    return Row(
+      children: [
+        Expanded(
+          flex: 3,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 33.0, horizontal: 0),
+            child: Center(
+              child: Container(
+                width: 651,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(28),
+                  color: const Color(0xFFF7F5F2),
+                ),
+                child: Stack(
+                  children: [
+                    Positioned(
+                      top: 16,
+                      left: 16,
+                      child: Image.asset(
+                        'assets/images/logo_desktop.png',
+                        width: 48,
+                        height: 69,
+                        fit: BoxFit.contain,
+                      ),
+                    ),
+                    Center(
+                      child: Image.asset(
+                        'assets/images/signUp_images/Sign_up_img.png',
+                        width: 651,
+                        height: 630,
+                        fit: BoxFit.contain,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: Padding(
+            padding:
+                const EdgeInsets.only(right: 50.0, top: 33.0, bottom: 33.0),
+            child: _buildMobileLayout(textTheme),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/ui/screens/welcome_page_screens/welcome_screen.dart
+++ b/lib/src/ui/screens/welcome_page_screens/welcome_screen.dart
@@ -9,7 +9,6 @@ import '../../../localization/app_localizations.dart';
 import '../../widgets/responsive/responsive_design.dart';
 import '../../widgets/welcome_page_widgets/left_section.dart';
 
-
 class WelcomeScreen extends ConsumerWidget {
   const WelcomeScreen({super.key});
 
@@ -213,7 +212,7 @@ class WelcomeText extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [

--- a/lib/src/ui/screens/welcome_page_screens/welcome_screen.dart
+++ b/lib/src/ui/screens/welcome_page_screens/welcome_screen.dart
@@ -9,11 +9,11 @@ import '../../../localization/app_localizations.dart';
 import '../../widgets/responsive/responsive_design.dart';
 import '../../widgets/welcome_page_widgets/left_section.dart';
 
-class WelcomeScreen extends StatelessWidget {
+class WelcomeScreen extends ConsumerWidget {
   const WelcomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return const Scaffold(
       body: TResponsiveWidget(
           desktop: Padding(
@@ -26,11 +26,12 @@ class WelcomeScreen extends StatelessWidget {
   }
 }
 
-class Desktop extends StatelessWidget {
+class Desktop extends ConsumerWidget {
   const Desktop({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
       body: Row(
         children: [
@@ -53,7 +54,7 @@ class Desktop extends StatelessWidget {
                       const WelcomeText(),
                       const SizedBox(height: 36),
                       CustomButton(
-                        text: "Зареєструватись",
+                        text: l10n.signUp,
                         onPressed: () {
                           Navigator.pushNamed(context, '/registration');
                         },
@@ -62,7 +63,7 @@ class Desktop extends StatelessWidget {
                       ),
                       const SizedBox(height: 8),
                       CustomButton(
-                        text: "Увійти",
+                        text: l10n.signIn,
                         onPressed: () {
                           Navigator.pushNamed(context, '/login');
                         },
@@ -78,9 +79,9 @@ class Desktop extends StatelessWidget {
                     onPressed: () {
                       Navigator.pushNamed(context, '/main');
                     },
-                    child: const Text(
-                      'Пропустити цей крок',
-                      style: TextStyle(
+                    child: Text(
+                      l10n.skipStep,
+                      style: const TextStyle(
                         color: Color(0xFF8E8E8E),
                         fontSize: 15,
                         decoration: TextDecoration.none,
@@ -107,11 +108,11 @@ class Tablet extends StatelessWidget {
   }
 }
 
-class Mobile extends StatelessWidget {
+class Mobile extends ConsumerWidget {
   const Mobile({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: AppTheme.backgroundColorWhite,
@@ -204,26 +205,28 @@ class Mobile extends StatelessWidget {
   }
 }
 
-class WelcomeText extends StatelessWidget {
+class WelcomeText extends ConsumerWidget {
   const WelcomeText({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const Column(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    
+    return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Text(
-          "Привіт!",
-          style: TextStyle(
+          l10n.welcomeTitle,
+          style: const TextStyle(
             fontSize: 32,
             fontWeight: FontWeight.bold,
           ),
         ),
-        SizedBox(height: 8),
+        const SizedBox(height: 8),
         Text(
-          "Отримай безпечний досвід покупок\n разом з нами",
+          l10n.welcomeSubtitle,
           textAlign: TextAlign.center,
-          style: TextStyle(
+          style: const TextStyle(
             fontSize: 16,
             color: AppTheme.lightBodyColor,
           ),

--- a/lib/src/ui/screens/welcome_page_screens/welcome_screen.dart
+++ b/lib/src/ui/screens/welcome_page_screens/welcome_screen.dart
@@ -9,19 +9,21 @@ import '../../../localization/app_localizations.dart';
 import '../../widgets/responsive/responsive_design.dart';
 import '../../widgets/welcome_page_widgets/left_section.dart';
 
+
 class WelcomeScreen extends ConsumerWidget {
   const WelcomeScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Scaffold(
+    return Scaffold(
       body: TResponsiveWidget(
-          desktop: Padding(
-            padding: EdgeInsets.symmetric(vertical: 33.0, horizontal: 61.0),
-            child: Desktop(),
-          ),
-          tablet: Tablet(),
-          mobile: Mobile()),
+        desktop: Padding(
+          padding: EdgeInsets.symmetric(vertical: 33.0, horizontal: 61.0),
+          child: Desktop(),
+        ),
+        tablet: Tablet(),
+        mobile: Mobile(),
+      ),
     );
   }
 }

--- a/lib/src/ui/widgets/debug/localization_debug.dart
+++ b/lib/src/ui/widgets/debug/localization_debug.dart
@@ -10,7 +10,7 @@ class LocalizationDebug extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final currentLanguage = ref.watch(languageProvider);
-    
+
     return Container(
       padding: const EdgeInsets.all(16),
       margin: const EdgeInsets.all(8),
@@ -44,12 +44,16 @@ class LocalizationDebug extends ConsumerWidget {
           Row(
             children: [
               ElevatedButton(
-                onPressed: () => ref.read(languageProvider.notifier).changeLanguage(AppLanguage.ukrainian),
+                onPressed: () => ref
+                    .read(languageProvider.notifier)
+                    .changeLanguage(AppLanguage.ukrainian),
                 child: const Text('Force UA'),
               ),
               const SizedBox(width: 8),
               ElevatedButton(
-                onPressed: () => ref.read(languageProvider.notifier).changeLanguage(AppLanguage.english),
+                onPressed: () => ref
+                    .read(languageProvider.notifier)
+                    .changeLanguage(AppLanguage.english),
                 child: const Text('Force EN'),
               ),
             ],
@@ -58,4 +62,4 @@ class LocalizationDebug extends ConsumerWidget {
       ),
     );
   }
-} 
+}

--- a/lib/src/ui/widgets/debug/localization_debug.dart
+++ b/lib/src/ui/widgets/debug/localization_debug.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../localization/app_localizations.dart';
+import '../../../providers/language_provider.dart';
+
+class LocalizationDebug extends ConsumerWidget {
+  const LocalizationDebug({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final currentLanguage = ref.watch(languageProvider);
+    
+    return Container(
+      padding: const EdgeInsets.all(16),
+      margin: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.red, width: 2),
+        borderRadius: BorderRadius.circular(8),
+        color: Colors.yellow.withOpacity(0.3),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '🐛 DEBUG LOCALIZATION',
+            style: const TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.red,
+              fontSize: 16,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text('Current Language: ${currentLanguage.displayCode}'),
+          Text('Locale: ${currentLanguage.languageCode}'),
+          const SizedBox(height: 8),
+          Text('Translations Test:'),
+          Text('- signUp: "${l10n.signUp}"'),
+          Text('- signIn: "${l10n.signIn}"'),
+          Text('- home: "${l10n.home}"'),
+          Text('- welcomeTitle: "${l10n.welcomeTitle}"'),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              ElevatedButton(
+                onPressed: () => ref.read(languageProvider.notifier).changeLanguage(AppLanguage.ukrainian),
+                child: const Text('Force UA'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: () => ref.read(languageProvider.notifier).changeLanguage(AppLanguage.english),
+                child: const Text('Force EN'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+} 

--- a/lib/src/ui/widgets/login_widgets/login_header.dart
+++ b/lib/src/ui/widgets/login_widgets/login_header.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_application_1/constants/colors.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../localization/app_localizations.dart';
 
-class LoginHeader extends StatelessWidget {
+class LoginHeader extends ConsumerWidget {
   const LoginHeader({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
     return Column(
       children: [
         // const SizedBox(height: 111),
@@ -13,13 +16,13 @@ class LoginHeader extends StatelessWidget {
         //   text: 'SHUM',
         // ),
         Text(
-          'Вхід',
+          l10n.signIn,
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.titleLarge?.copyWith(fontSize: 32),
         ),
         const SizedBox(height: 8),
         Text(
-          'Вітаємо знову у Shum! ',
+          l10n.welcomeBack,
           textAlign: TextAlign.center,
           style: Theme.of(context)
               .textTheme

--- a/lib/src/ui/widgets/login_widgets/login_mobile_layout.dart
+++ b/lib/src/ui/widgets/login_widgets/login_mobile_layout.dart
@@ -8,8 +8,10 @@ import 'package:flutter_application_1/src/ui/widgets/auth_widgets/auth_button.da
 import 'package:flutter_application_1/src/ui/widgets/shared_widgets/language_selector.dart';
 import 'package:flutter_application_1/src/ui/widgets/social_media/social_media.dart';
 import 'package:flutter_application_1/src/utils/validators.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../localization/app_localizations.dart';
 
-class LoginMobileLayout extends StatelessWidget {
+class LoginMobileLayout extends ConsumerWidget {
   final TextTheme textTheme;
   final GlobalKey<FormState> formKey;
   final TextEditingController emailController;
@@ -28,7 +30,8 @@ class LoginMobileLayout extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -59,8 +62,8 @@ class LoginMobileLayout extends StatelessWidget {
                       const LoginHeader(),
                       const SizedBox(height: 40),
                       AuthField(
-                        labelText: 'Ваша пошта',
-                        hintText: "Введіть пошту",
+                        labelText: l10n.yourEmail,
+                        hintText: l10n.enterEmail,
                         controller: emailController,
                         validator: validateEmail,
                         showSuffixIcon: (text) {
@@ -69,8 +72,8 @@ class LoginMobileLayout extends StatelessWidget {
                       ),
                       const SizedBox(height: 12),
                       AuthField(
-                        labelText: 'Пароль',
-                        hintText: "Введіть пароль",
+                        labelText: l10n.password,
+                        hintText: l10n.enterPassword,
                         controller: passwordController,
                         validator: validatePassword,
                         isObscureText: true,
@@ -81,7 +84,7 @@ class LoginMobileLayout extends StatelessWidget {
                               : null),
                       const SizedBox(height: 40),
                       AuthButton(
-                        text: 'Увійти в акаунт',
+                        text: l10n.signInAccount,
                         onPressed: onLogin,
                         isButtonDisabled: isButtonDisabled,
                       ),
@@ -103,10 +106,10 @@ class LoginMobileLayout extends StatelessWidget {
                         child: RichText(
                           text: TextSpan(
                             style: Theme.of(context).textTheme.bodyMedium,
-                            children: const [
-                              TextSpan(text: 'Ще не маєте акаунт? '),
+                            children: [
+                              TextSpan(text: l10n.dontHaveAccount + ' '),
                               TextSpan(
-                                text: ' Зареєструватись',
+                                text: l10n.signUp,
                                 style: TextStyle(
                                   color: TColors.orange,
                                 ),

--- a/lib/src/ui/widgets/main_screen_widgets/desktop/appbar_buttons.dart
+++ b/lib/src/ui/widgets/main_screen_widgets/desktop/appbar_buttons.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../utils/auth_validator.dart';
 import '../../../themes/app_theme.dart';
+import '../../../../localization/app_localizations.dart';
 
-class MainAuthButtons extends StatelessWidget {
+class MainAuthButtons extends ConsumerWidget {
   const MainAuthButtons({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
     return TokenBasedWidget(
       child: Row(
         children: [
@@ -20,7 +23,7 @@ class MainAuthButtons extends StatelessWidget {
                 borderRadius: BorderRadius.circular(8),
               ),
             ),
-            child: const Text('Увійти'),
+            child: Text(l10n.signIn),
           ),
           const SizedBox(width: 8),
           OutlinedButton(
@@ -31,9 +34,9 @@ class MainAuthButtons extends StatelessWidget {
                 borderRadius: BorderRadius.circular(8),
               ),
             ),
-            child: const Text(
-              'Завантажити застосунок',
-              style: TextStyle(color: AppTheme.linkTextColor),
+            child: Text(
+              l10n.downloadApp,
+              style: const TextStyle(color: AppTheme.linkTextColor),
             ),
           ),
         ],

--- a/lib/src/ui/widgets/main_screen_widgets/desktop/footer_desktop.dart
+++ b/lib/src/ui/widgets/main_screen_widgets/desktop/footer_desktop.dart
@@ -12,7 +12,7 @@ class FooterSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    
+
     final List<Map<String, dynamic>> listSections = [
       {
         'title': l10n.pages,

--- a/lib/src/ui/widgets/main_screen_widgets/desktop/footer_desktop.dart
+++ b/lib/src/ui/widgets/main_screen_widgets/desktop/footer_desktop.dart
@@ -1,47 +1,50 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../utils/auth_validator.dart';
 import '../../../themes/app_theme.dart';
 import '../../shared_widgets/language_selector.dart';
+import '../../../../localization/app_localizations.dart';
 
-class FooterSection extends StatelessWidget {
+class FooterSection extends ConsumerWidget {
   FooterSection({super.key});
 
-  final List<Map<String, dynamic>> listSections = [
-    {
-      'title': 'Сторінки',
-      'items': [
-        'Категорії',
-        'Сезонні пропозиції',
-        'Нові оголошення',
-        'Сповіщення',
-        'Відгуки',
-        'Рекомендовані товари',
-        'Історія',
-      ],
-    },
-    {
-      'title': 'Інше',
-      'items': [
-        'Доставка та оплата',
-        'Питання',
-        'Пошук',
-        'Продати',
-        'Чат',
-        'Обране',
-      ],
-    },
-    {
-      'title': 'Контакти',
-      'items': [
-        'Про нас',
-        'Підтримка',
-      ],
-    },
-  ];
-
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    
+    final List<Map<String, dynamic>> listSections = [
+      {
+        'title': l10n.pages,
+        'items': [
+          l10n.categories,
+          l10n.seasonalOffers,
+          l10n.newAds,
+          l10n.notifications,
+          l10n.reviews,
+          l10n.recommendedProducts,
+          l10n.history,
+        ],
+      },
+      {
+        'title': l10n.other,
+        'items': [
+          l10n.delivery,
+          l10n.questions,
+          l10n.search,
+          l10n.sell,
+          l10n.chat,
+          l10n.favorites,
+        ],
+      },
+      {
+        'title': l10n.contacts,
+        'items': [
+          l10n.about,
+          l10n.support,
+        ],
+      },
+    ];
     return Container(
       padding: const EdgeInsets.fromLTRB(30, 30, 30, 12),
       decoration: BoxDecoration(

--- a/lib/src/ui/widgets/main_screen_widgets/mobile/footerBar.dart
+++ b/lib/src/ui/widgets/main_screen_widgets/mobile/footerBar.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../themes/app_theme.dart';
+import '../../../../localization/app_localizations.dart';
 
-class FooterBarWidget extends StatefulWidget {
+class FooterBarWidget extends ConsumerStatefulWidget {
   const FooterBarWidget({super.key});
 
   @override
   FooterBarWidgetState createState() => FooterBarWidgetState();
 }
 
-class FooterBarWidgetState extends State<FooterBarWidget> {
+class FooterBarWidgetState extends ConsumerState<FooterBarWidget> {
   int _selectedIndex = 0;
 
   void _navigateBottomBar(int index) {
@@ -21,6 +23,7 @@ class FooterBarWidgetState extends State<FooterBarWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Container(
       decoration: const BoxDecoration(
         color: AppTheme.backgroundColorWhite,
@@ -46,23 +49,23 @@ class FooterBarWidgetState extends State<FooterBarWidget> {
             items: [
               BottomNavigationBarItem(
                 icon: _buildIcon('assets/images/footer_icons/home.svg', 0),
-                label: 'Головна',
+                label: l10n.home,
               ),
               BottomNavigationBarItem(
                 icon: _buildIcon('assets/images/footer_icons/search.svg', 1),
-                label: 'Пошук',
+                label: l10n.search,
               ),
               BottomNavigationBarItem(
                 icon: _buildIcon('assets/images/footer_icons/add.svg', 2),
-                label: 'Продати',
+                label: l10n.sell,
               ),
               BottomNavigationBarItem(
                 icon: _buildIcon('assets/images/footer_icons/message.svg', 3),
-                label: 'Чат',
+                label: l10n.chat,
               ),
               BottomNavigationBarItem(
                 icon: _buildIcon('assets/images/footer_icons/profile.svg', 4),
-                label: 'Акаунт',
+                label: l10n.account,
               ),
             ],
           ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,30 @@
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility in the flutter_test package. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_application_1/main.dart';
+
+void main() {
+  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const MyApp());
+
+    // Verify that our counter starts at 0.
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+
+    // Tap the '+' icon and trigger a frame.
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+
+    // Verify that our counter has incremented.
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary by Sourcery

Add full Ukrainian and English localization support to the app by extending AppLocalizations with new translation keys, converting UI widgets to ConsumerWidgets for Riverpod-based locale lookup, replacing hardcoded strings across screens, and providing a debug panel for locale testing. Also include a simple widget test for counter behavior.

New Features:
- Add Ukrainian and English translation resources covering welcome, registration, login, navigation, footer sections, and more
- Introduce a LocalizationDebug widget to inspect and force app locale for testing

Enhancements:
- Refactor multiple UI components (welcome screen, login, registration, footer, appbar) to use localized strings via Riverpod ConsumerWidgets
- Replace all hardcoded text with l10n properties and integrate Riverpod language support for dynamic localization

Tests:
- Add a basic Flutter widget test to verify counter increment functionality